### PR TITLE
[Issue 4.1] Standardize beam_width default to 4

### DIFF
--- a/gene.py
+++ b/gene.py
@@ -457,7 +457,7 @@ class Searcher:
         origin_road_id,
         origin_datetime,
         destination_road_id,
-        beam_width=8,
+        beam_width=4,
         max_search_step=5000,
     ):
         """Beam search that processes multiple candidates in parallel for better GPU utilization"""
@@ -2217,7 +2217,10 @@ if __name__ == "__main__":
         help="Use beam search instead of A* search",
     )
     parser.add_argument(
-        "--beam_width", type=int, default=8, help="Beam width for beam search"
+        "--beam_width",
+        type=int,
+        default=4,
+        help="Beam width for beam search (default: 4, standard across all scripts)",
     )
     parser.add_argument(
         "--vectorized", action="store_true", help="Use vectorized GPU-parallel search"


### PR DESCRIPTION
## Summary

Fixes beam_width default inconsistency across scripts.

Fixes #27

## Problem

Found inconsistent beam_width defaults:
- ❌ `gene.py`: Used `beam_width=8` (method default and CLI argument)
- ✅ `config/evaluation.yaml`: Used `beam_width=4`
- ✅ `python_pipeline.py`: Used `beam_width=4`
- ✅ `tools/generate_abnormal_od.py`: Used `beam_width=4`
- ✅ Beam search ablation study (Issue #8): Tested with `width=4`

## Changes Made

1. **gene.py line 460** - Method default parameter
   - Changed: `beam_width=8` → `beam_width=4`

2. **gene.py line 2220** - CLI argument default
   - Changed: `default=8` → `default=4`
   - Enhanced help text: Now indicates "default: 4, standard across all scripts"

## Rationale

Standardized to **beam_width=4** because:
1. ✅ Config files explicitly set `beam_width: 4`
2. ✅ Pipeline code defaults to `4`
3. ✅ Ablation study (26 hours of experiments) used `4`
4. ✅ All documentation references width `4`

## Impact

**Before**: Scripts called without explicit `--beam_width` could use either 4 or 8 depending on entry point  
**After**: All scripts default to `beam_width=4` consistently

This prevents:
- Reproducibility issues from conflicting defaults
- Confusion about which beam width was used
- Results that don't match documented experiments

## Validation

- ✅ All beam_width defaults audited
- ✅ Inconsistencies identified (gene.py)
- ✅ Defaults standardized to 4
- ✅ Ruff checks passed
- ✅ Consistency verified

## Files Modified

- `gene.py` (2 changes, 5 insertions, 2 deletions)

**Total**: 1 file, 3 lines changed